### PR TITLE
introduce options for configuring api calls

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -103,9 +103,9 @@ func (cm *ClientManager) Create(c *Client) (err error) {
 	return cm.m.post(cm.m.uri("clients"), c)
 }
 
-func (cm *ClientManager) Read(id string) (*Client, error) {
+func (cm *ClientManager) Read(id string, opts ...Option) (*Client, error) {
 	c := new(Client)
-	err := cm.m.get(cm.m.uri("clients", id), c)
+	err := cm.m.get(cm.m.uri("clients", id)+"?"+cm.m.q(opts), c)
 	return c, err
 }
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -96,9 +96,9 @@ func (cm *ConnectionManager) Create(c *Connection) error {
 	return cm.m.post(cm.m.uri("connections"), c)
 }
 
-func (cm *ConnectionManager) Read(id string) (*Connection, error) {
+func (cm *ConnectionManager) Read(id string, opts ...Option) (*Connection, error) {
 	c := new(Connection)
-	err := cm.m.get(cm.m.uri("connections", id), c)
+	err := cm.m.get(cm.m.uri("connections", id)+"?"+cm.m.q(opts), c)
 	return c, err
 }
 

--- a/management/custom_domain.go
+++ b/management/custom_domain.go
@@ -44,9 +44,9 @@ func (cm *CustomDomainManager) Create(c *CustomDomain) (err error) {
 	return cm.m.post(cm.m.uri("custom-domains"), c)
 }
 
-func (cm *CustomDomainManager) Read(id string) (*CustomDomain, error) {
+func (cm *CustomDomainManager) Read(id string, opts ...Option) (*CustomDomain, error) {
 	c := new(CustomDomain)
-	err := cm.m.get(cm.m.uri("custom-domains", id), c)
+	err := cm.m.get(cm.m.uri("custom-domains", id)+"?"+cm.m.q(opts), c)
 	return c, err
 }
 

--- a/management/email.go
+++ b/management/email.go
@@ -49,9 +49,9 @@ func (em *EmailManager) Create(e *Email) error {
 	return em.m.post(em.m.uri("emails", "provider"), e)
 }
 
-func (em *EmailManager) Read() (*Email, error) {
+func (em *EmailManager) Read(opts ...Option) (*Email, error) {
 	e := new(Email)
-	err := em.m.get(em.m.uri("emails", "provider")+"?fields=name,enabled,default_from_address,credentials", e)
+	err := em.m.get(em.m.uri("emails", "provider")+"?"+em.m.q(opts), e)
 	return e, err
 }
 

--- a/management/email_template.go
+++ b/management/email_template.go
@@ -42,9 +42,9 @@ func (em *EmailTemplateManager) Create(e *EmailTemplate) error {
 	return em.m.post(em.m.uri("email-templates"), e)
 }
 
-func (em *EmailTemplateManager) Read(template string) (*EmailTemplate, error) {
+func (em *EmailTemplateManager) Read(template string, opts ...Option) (*EmailTemplate, error) {
 	e := new(EmailTemplate)
-	err := em.m.get(em.m.uri("email-templates", template), e)
+	err := em.m.get(em.m.uri("email-templates", template)+"?"+em.m.q(opts), e)
 	return e, err
 }
 

--- a/management/management.go
+++ b/management/management.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -161,11 +163,20 @@ func New(domain, clientID, clientSecret string) (*Management, error) {
 	return m, nil
 }
 
-func (m *Management) uri(parts ...string) string {
-	return fmt.Sprintf("https://%s/%s/%s",
-		m.domain,
-		m.basePath,
-		strings.Join(parts, "/"))
+func (m *Management) uri(path ...string) string {
+	return (&url.URL{
+		Scheme: "https",
+		Host:   m.domain,
+		Path:   m.basePath + "/" + strings.Join(path, "/"),
+	}).String()
+}
+
+func (m *Management) q(options []Option) string {
+	v := make(url.Values)
+	for _, option := range options {
+		option(v)
+	}
+	return v.Encode()
 }
 
 func (m *Management) get(uri string, v interface{}) error {
@@ -360,4 +371,54 @@ func (m *managementError) Error() string {
 
 func (m *managementError) Status() int {
 	return m.StatusCode
+}
+
+// Option configures a call (typically to retrieve a resource) to Auth0 with
+// query parameters.
+type Option func(v url.Values)
+
+// WithFields configures a call to include the desired fields.
+func WithFields(fields ...string) Option {
+	return func(v url.Values) {
+		v.Set("fields", strings.Join(fields, ","))
+		v.Set("include_fields", "true")
+	}
+}
+
+// WithoutFields configures a call to exclude the desired fields.
+func WithoutFields(fields ...string) Option {
+	return func(v url.Values) {
+		v.Set("fields", strings.Join(fields, ","))
+		v.Set("include_fields", "false")
+	}
+}
+
+// Page configures a call to receive a specific page, if the results where
+// concatenated.
+func Page(page int) Option {
+	return func(v url.Values) {
+		v.Set("page", strconv.FormatInt(int64(page), 10))
+	}
+}
+
+// PerPage configures a call to limit the amount of items in the result.
+func PerPage(items int) Option {
+	return func(v url.Values) {
+		v.Set("per_page", strconv.FormatInt(int64(items), 10))
+	}
+}
+
+// IncludeTotals configures a call to include totals.
+func IncludeTotals(include bool) Option {
+	return func(v url.Values) {
+		v.Set("include_totals", strconv.FormatBool(include))
+	}
+}
+
+// Parameter is a generic configuration to add arbitrary query parameters to
+// calls made to Auth0.
+func Parameter(key, value string) Option {
+	return func(v url.Values) {
+		v.Set(key, value)
+	}
 }

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -1,6 +1,8 @@
 package management
 
-import "os"
+import (
+	"os"
+)
 
 var m *Management
 

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -1,7 +1,9 @@
 package management
 
 import (
+	"net/url"
 	"os"
+	"testing"
 )
 
 var m *Management
@@ -17,5 +19,69 @@ func init() {
 	m, err = New(Auth0Domain, Auth0ClientID, Auth0ClientSecret)
 	if err != nil {
 		panic(err)
+	}
+}
+
+func TestOptionFields(t *testing.T) {
+	v := make(url.Values)
+	WithFields("foo", "bar")(v)
+
+	fields := v.Get("fields")
+	if fields != "foo,bar" {
+		t.Errorf("Expected %q, but got %q", fields, "foo,bar")
+	}
+
+	includeFields := v.Get("include_fields")
+	if includeFields != "true" {
+		t.Errorf("Expected %q, but got %q", includeFields, "true")
+	}
+
+	WithoutFields("foo", "bar")(v)
+
+	includeFields = v.Get("include_fields")
+	if includeFields != "false" {
+		t.Errorf("Expected %q, but got %q", includeFields, "true")
+	}
+}
+
+func TestOptionPage(t *testing.T) {
+	v := make(url.Values)
+	Page(3)(v)
+	PerPage(10)(v)
+
+	page := v.Get("page")
+	if page != "3" {
+		t.Errorf("Expected %q, but got %q", page, "3")
+	}
+
+	perPage := v.Get("per_page")
+	if perPage != "10" {
+		t.Errorf("Expected %q, but got %q", perPage, "3")
+	}
+}
+
+func TestOptionTotals(t *testing.T) {
+	v := make(url.Values)
+	IncludeTotals(true)(v)
+
+	includeTotals := v.Get("include_totals")
+	if includeTotals != "true" {
+		t.Errorf("Expected %q, but got %q", includeTotals, "true")
+	}
+}
+
+func TestOptionParameter(t *testing.T) {
+	v := make(url.Values)
+	Parameter("foo", "123")(v)
+	Parameter("bar", "xyz")(v)
+
+	foo := v.Get("foo")
+	if foo != "123" {
+		t.Errorf("Expected %q, but got %q", foo, "123")
+	}
+
+	bar := v.Get("bar")
+	if bar != "xyz" {
+		t.Errorf("Expected %q, but got %q", bar, "xyz")
 	}
 }

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -59,9 +59,9 @@ func (r *ResourceServerManager) Create(rs *ResourceServer) (err error) {
 	return r.m.post(r.m.uri("resource-servers"), rs)
 }
 
-func (r *ResourceServerManager) Read(id string) (*ResourceServer, error) {
+func (r *ResourceServerManager) Read(id string, opts ...Option) (*ResourceServer, error) {
 	rs := new(ResourceServer)
-	err := r.m.get(r.m.uri("resource-servers", id), rs)
+	err := r.m.get(r.m.uri("resource-servers", id)+"?"+r.m.q(opts), rs)
 	return rs, err
 }
 

--- a/management/rule.go
+++ b/management/rule.go
@@ -33,9 +33,9 @@ func (rm *RuleManager) Create(r *Rule) error {
 	return rm.m.post(rm.m.uri("rules"), r)
 }
 
-func (rm *RuleManager) Read(id string) (*Rule, error) {
+func (rm *RuleManager) Read(id string, opts ...Option) (*Rule, error) {
 	r := new(Rule)
-	err := rm.m.get(rm.m.uri("rules", id), r)
+	err := rm.m.get(rm.m.uri("rules", id)+"?"+rm.m.q(opts), r)
 	return r, err
 }
 


### PR DESCRIPTION
In order to support passing options to the Auth0 API we needed a way to set query parameters to the calls.

This PR adds support for setting such options via optional [functional arguments](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis).

For the time being, options are allowed in most `Read` operations. If its needed in other operations we can examine the use case.

*Warning*: This has a small BC change with the Email Provider resource where we hard coded the options inside the read call. This is now removed.