### PR TITLE
Add requires_username option to auth0 connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -71,6 +71,7 @@ type ConnectionOptions struct {
 	BruteForceProtection         bool `json:"brute_force_protection,omitempty"`
 	ImportMode                   bool `json:"import_mode,omitempty"`
 	DisableSignup                bool `json:"disable_signup,omitempty"`
+	RequiresUsername             bool `json:"requires_username,omitempty"`
 
 	// Options for adding parameters in the request to the upstream IdP.
 	UpstreamParams interface{} `json:"upstream_params,omitempty"`
@@ -90,7 +91,6 @@ type ConnectionOptions struct {
 	CustomScripts map[string]interface{} `json:"custom_scripts,omitempty"`
 	// configuration variables that can be used in custom scripts
 	Configuration map[string]interface{} `json:"configuration,omitempty"`
-
 }
 
 type ConnectionManager struct {

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -37,8 +37,9 @@ func TestConnection(t *testing.T) {
 		c.Name = ""     // read-only
 		c.Strategy = "" // read-only
 		c.Options = &ConnectionOptions{
-			CustomScripts: map[string]interface{}{"get_user": "function(email, callback) { return callback(null) }"},
-			Configuration: map[string]interface{}{"foo": "bar"},
+			CustomScripts:    map[string]interface{}{"get_user": "function(email, callback) { return callback(null) }"},
+			Configuration:    map[string]interface{}{"foo": "bar"},
+			RequiresUsername: true,
 		}
 
 		cc := c // make a copy so we can compare later
@@ -55,6 +56,10 @@ func TestConnection(t *testing.T) {
 
 		if _, exist := c.Options.Configuration["foo"]; !exist {
 			t.Fatal(`missing key "foo"`)
+		}
+
+		if c.Options.RequiresUsername != cc.Options.RequiresUsername {
+			t.Fatalf("expected requires_username to be %v but got %v", cc.Options.RequiresUsername, c.Options.RequiresUsername)
 		}
 	})
 


### PR DESCRIPTION
This variable is currently almost undocumented on auth0, but
it works fine for an auth0 database connection.