### PR TITLE
customScripts was not working with the Auth0 API

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -88,7 +88,7 @@ type ConnectionOptions struct {
 
 	// Scripts for the connction
 	// Allowed keys are: "get_user", "login", "create", "verify", "change_password" or "delete".
-	CustomScripts map[string]interface{} `json:"custom_scripts,omitempty"`
+	CustomScripts map[string]interface{} `json:"customScripts,omitempty"`
 	// configuration variables that can be used in custom scripts
 	Configuration map[string]interface{} `json:"configuration,omitempty"`
 }


### PR DESCRIPTION
The API was receiving the property `custom_script`, but it was expecting `customScript`.
The key is not documented in the [get_connections_response_options](https://auth0.com/docs/api/management/v2#!/Connections/get_connections) nor the get_connections_by_id_response_options](https://auth0.com/docs/api/management/v2#!/Connections/get_connections_by_id), so the only way to see it is an API request for a connection with a custom DB script.