### PR TITLE
Add IsDomainConnection property to Connection struct

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -27,6 +27,9 @@ type Connection struct {
 	// "yammer" or "yandex".
 	Strategy *string `json:"strategy,omitempty"`
 
+	// True if the connection is domain level
+	IsDomainConnection *bool `json:"is_domain_connection,omitempty"`
+
 	// Options for validation.
 	Options *ConnectionOptions `json:"options,omitempty"`
 
@@ -65,7 +68,6 @@ type ConnectionOptions struct {
 
 	// Options for password dictionary policy.
 	PasswordDictionary map[string]interface{} `json:"password_dictionary,omitempty"`
-
 
 	APIEnableUsers               *bool `json:"api_enable_users,omitempty"`
 	BasicProfile                 *bool `json:"basic_profile,omitempty"`


### PR DESCRIPTION
This PR adds ability to specify **is_domain_connection** property for auth0 connections. Only domain level connections can be used with third-party clients. 