### PR TITLE
Add is_token_endpoint_ip_header_trusted property support to Client

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -26,6 +26,10 @@ type Client struct {
 	// Whether this client a first party client or not
 	IsFirstParty *bool `json:"is_first_party,omitempty"`
 
+	// Set header `auth0-forwarded-for` as trusted to be used as source
+	// of end user ip for brute-force-protection on token endpoint.
+	IsTokenEndpointIPHeaderTrusted *bool `json:"is_token_endpoint_ip_header_trusted,omitempty"`
+
 	// Whether this client will conform to strict OIDC specifications
 	OIDCConformant *bool `json:"oidc_conformant,omitempty"`
 


### PR DESCRIPTION
This PR introduces ability to change is_token_endpoint_ip_header_trusted property to clients.

There is no documentation regarding the property, but the api returns and allows to change the value of it.

p.s. I've been told by auth0 support that they will update the documentation 