### PR TITLE
User timestamps

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -32,6 +32,9 @@ type User struct {
 	// The last time the user is updated.
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
+	// The last time the user has logged in.
+	LastLogin *time.Time `json:"last_login,omitempty"`
+
 	// UserMetadata holds data that the user has read/write access to (e.g.
 	// color_preference, blog_url, etc).
 	UserMetadata map[string]interface{} `json:"user_metadata,omitempty"`

--- a/management/user.go
+++ b/management/user.go
@@ -1,6 +1,9 @@
 package management
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 type User struct {
 
@@ -22,6 +25,9 @@ type User struct {
 	// The user's phone number (following the E.164 recommendation), only valid
 	// for users to be added to SMS connections.
 	PhoneNumber *string `json:"phone_number,omitempty"`
+
+	// The time the user is created.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// UserMetadata holds data that the user has read/write access to (e.g.
 	// color_preference, blog_url, etc).

--- a/management/user.go
+++ b/management/user.go
@@ -29,6 +29,9 @@ type User struct {
 	// The time the user is created.
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 
+	// The last time the user is updated.
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+
 	// UserMetadata holds data that the user has read/write access to (e.g.
 	// color_preference, blog_url, etc).
 	UserMetadata map[string]interface{} `json:"user_metadata,omitempty"`


### PR DESCRIPTION
I've added the `created_at`, `updated_at` and `last_login` fields for [this endpoint](https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id)