### PR TITLE
fix: do not omit empty scope list on client grant

### DIFF
--- a/management/client_grant.go
+++ b/management/client_grant.go
@@ -17,7 +17,7 @@ type ClientGrant struct {
 	// The audience.
 	Audience *string `json:"audience,omitempty"`
 
-	Scope []interface{} `json:"scope,omitempty"`
+	Scope []interface{} `json:"scope"`
 }
 
 func (c *ClientGrant) String() string {


### PR DESCRIPTION
The auth0 management requires at least an empty list: https://auth0.com/docs/api/management/v2#!/Client_Grants/post_client_grants