### PR TITLE
add additional fields to User

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3931,6 +3931,22 @@ func (u *User) GetCreatedAt() time.Time {
 	return *u.CreatedAt
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *User) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
+// GetDistinguishedName returns the DistinguishedName field if it's non-nil, zero value otherwise.
+func (u *User) GetDistinguishedName() string {
+	if u == nil || u.DistinguishedName == nil {
+		return ""
+	}
+	return *u.DistinguishedName
+}
+
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
 func (u *User) GetEmail() string {
 	if u == nil || u.Email == nil {
@@ -3979,6 +3995,22 @@ func (u *User) GetLastLogin() time.Time {
 	return *u.LastLogin
 }
 
+// GetLoginsCount returns the LoginsCount field.
+func (u *User) GetLoginsCount() *int32 {
+	if u == nil {
+		return nil
+	}
+	return u.LoginsCount
+}
+
+// GetManager returns the Manager field if it's non-nil, zero value otherwise.
+func (u *User) GetManager() string {
+	if u == nil || u.Manager == nil {
+		return ""
+	}
+	return *u.Manager
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (u *User) GetName() string {
 	if u == nil || u.Name == nil {
@@ -4025,6 +4057,22 @@ func (u *User) GetPicture() string {
 		return ""
 	}
 	return *u.Picture
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (u *User) GetStatus() string {
+	if u == nil || u.Status == nil {
+		return ""
+	}
+	return *u.Status
+}
+
+// GetTitle returns the Title field if it's non-nil, zero value otherwise.
+func (u *User) GetTitle() string {
+	if u == nil || u.Title == nil {
+		return ""
+	}
+	return *u.Title
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.

--- a/management/user.go
+++ b/management/user.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"encoding/json"
+	"net"
 	"reflect"
 	"strconv"
 	"time"
@@ -85,6 +86,33 @@ type User struct {
 
 	// True if the user is blocked from the application, false if the user is enabled
 	Blocked *bool `json:"blocked,omitempty"`
+
+	// The IP Address that the user last authenticated from
+	LastIP *net.IP `json:"last_ip,omitempty"`
+
+	// The number of times this user has authenticated
+	LoginsCount *int32 `json:"logins_count,omitempty"`
+
+	// Description may be provided by some connectors
+	Description *string `json:"description,omitempty"`
+
+	// Status may be provided by some connectors
+	Status *string `json:"status,omitempty"`
+
+	// Some connectors may provide multiple email addresses
+	Emails []string `json:"emails,omitempty"`
+
+	// These Roles may be provided by some connectors
+	ConnectorRoles []string `json:"roles,omitempty"`
+
+	// DN may be provided by the LDAP connector
+	DistinguishedName *string `json:"dn,omitempty"`
+
+	// May be provided by the LDAP connector (or others)
+	Title *string `json:"title,omitempty"`
+
+	// May be provided by the LDAP connector (or others)
+	Manager *string `json:"manager,omitempty"`
 }
 
 type UserIdentity struct {

--- a/management/user.go
+++ b/management/user.go
@@ -103,7 +103,7 @@ type User struct {
 	Emails []string `json:"emails,omitempty"`
 
 	// These Roles may be provided by some connectors
-	ConnectorRoles []string `json:"roles,omitempty"`
+	ConnectorRoles RolesList `json:"roles,omitempty"`
 
 	// DN may be provided by the LDAP connector
 	DistinguishedName *string `json:"dn,omitempty"`
@@ -174,6 +174,29 @@ func (i *UserIdentity) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(alias)
 }
+
+// LDAP returns a string for a single role, or []string for more than one.
+// This type normalizes them into something slice-like
+//
+type RolesList []string
+
+func (l *RolesList) UnmarshalJSON(data []byte) error {
+	if l == nil {
+		return nil
+	}
+	var ret []string
+	if err := json.Unmarshal(data, &ret); err != nil {
+		var single string
+		if err := json.Unmarshal(data, &single); err != nil {
+			return err
+		}
+		ret = []string{single}
+	}
+	*l = ret
+	return nil
+}
+
+var _ json.Unmarshaler = (*RolesList)(nil)
 
 type userBlock struct {
 	BlockedFor []*UserBlock `json:"blocked_for,omitempty"`


### PR DESCRIPTION
Some of these may be very specific to LDAP, but some are shared among two or more connectors. Finding use for this to extract LDAP Roles to map to Auth0 Roles. Others may find some or all of these fields useful as well.

Happy to trim or add as needed.