### PR TITLE
add summary field to Job

### DIFF
--- a/management/job.go
+++ b/management/job.go
@@ -40,6 +40,13 @@ type Job struct {
 	// A list of fields to be included in the CSV. If omitted, a set of
 	// predefined fields will be exported.
 	Fields []map[string]interface{} `json:"fields,omitempty"`
+	// Summary of completed job results
+	Summary *struct {
+		Failed   int `json:"failed"`
+		Updated  int `json:"updated"`
+		Inserted int `json:"inserted"`
+		Total    int `json:"total"`
+	} `json:"summary,omitempty"`
 
 	// A list of users. Used when importing users in bulk.
 	Users []map[string]interface{} `json:"users,omitempty"`


### PR DESCRIPTION
### Proposed Changes

* Add's `summary` field to Job, supporting bulk user import jobs

#### Acceptance Test Output

I dropped a `replace` directive in the `go.mod` of the tool I'm writing.

<details>

Example job with Summary printed to stdout:
```go
job, err := m.Job.Read(jobID)
if err != nil {
    return err
}
fmt.Printf("%+v\n", job)
```
outputs:
```json
{
  "id": "job_<<SNIP>>",
  "status": "completed",
  "type": "users_import",
  "created_at": "2021-09-17T15:17:39.575Z",
  "connection_id": "<<SNIP>>",
  "summary": {
    "failed": 2,
    "updated": 0,
    "inserted": 0,
    "total": 2
  }
}
```
</details>
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->