### PR TITLE
simple addition of missing get_logs_by_user endpoint

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -539,3 +539,11 @@ func (m *UserManager) Organizations(id string, opts ...RequestOption) (p *Organi
 	err = m.Request("GET", m.URI("users", id, "organizations"), &p, applyListDefaults(opts))
 	return
 }
+
+// List user's log entries
+//
+// See: https://auth0.com/docs/api/management/v2#!/Users/get_logs_by_user
+func (m *UserManager) Logs(id string, opts ...RequestOption) (l []*Log, err error) {
+	err = m.Request("GET", m.URI("users", id, "logs"), &l, opts...)
+	return
+}


### PR DESCRIPTION
### Proposed Changes

* Add a `Logs()` method to the `UserManager` that calls the `get_logs_by_user` endpoint, as a simpler way of getting user logs (that only relies on the `read:logs_users` role in auth0)
* Not wrapped in a List object because the current Log functions aren't either, so for consistency; did think about wrapping them all but that would be a breaking change for another day...

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->