### PR TITLE
Add `ShowAsButton` option

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -76,6 +76,9 @@ type Connection struct {
 
 	// Provisioning Ticket URL is Ticket URL for Active Directory/LDAP, etc.
 	ProvisioningTicketUrl *string `json:"provisioning_ticket_url,omitempty"`
+
+	// Display connection as a button.
+	ShowAsButton *bool `json:"show_as_button,omitempty"`
 }
 
 func (c *Connection) MarshalJSON() ([]byte, error) {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -949,6 +949,14 @@ func (c *Connection) GetProvisioningTicketUrl() string {
 	return *c.ProvisioningTicketUrl
 }
 
+// GetShowAsButton returns the ShowAsButton field if it's non-nil, zero value otherwise.
+func (c *Connection) GetShowAsButton() bool {
+	if c == nil || c.ShowAsButton == nil {
+		return false
+	}
+	return *c.ShowAsButton
+}
+
 // GetStrategy returns the Strategy field if it's non-nil, zero value otherwise.
 func (c *Connection) GetStrategy() string {
 	if c == nil || c.Strategy == nil {


### PR DESCRIPTION
### Proposed Changes

* Add a new `show_as_button` option to be able to show a connection as a button (related to https://github.com/alexkappa/terraform-provider-auth0/issues/493)

#### Acceptance Test Output

```
$ go test ./... -v -run TestUser
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->