### PR TITLE
Add note about repo having moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# THIS REPOSITORY HAS MOVED
+
+This repository has moved into the [Auth0](https://github.com/auth0) organization where it will be maintained at
+[github.com/auth0/go-auth0](https://github.com/auth0/go-auth0).
+
+
 # Auth0 Go SDK
 
 [![Go Reference](https://pkg.go.dev/badge/gopkg.in/auth0.v5.svg)](https://pkg.go.dev/gopkg.in/auth0.v5)


### PR DESCRIPTION
## Description

With this PR we aim at adding a notice on the README to inform users of the new ownership under the Auth0 org: https://github.com/auth0/go-auth0